### PR TITLE
HYDRAN-2129 Indefinite assets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-party-assets</artifactId>
-	<version>6.1</version>
+	<version>6.2</version>
 	<name>party-assets</name>
 	<properties>
 		<!-- PR3 import dependency versions -->

--- a/src/integration-test/java/se/sundsvall/partyassets/apptest/DraftAssetsIT.java
+++ b/src/integration-test/java/se/sundsvall/partyassets/apptest/DraftAssetsIT.java
@@ -133,6 +133,26 @@ class DraftAssetsIT extends AbstractAppTest {
 	}
 
 	@Test
+	void test09_updateDraftAssetSetIndefinitely() {
+		final var id = "abd6596f-45a0-4912-89e4-8cdcea9a043a";
+
+		setupCall()
+			.withHttpMethod(PATCH)
+			.withServicePath(PATH + "/" + id)
+			.withRequest(REQUEST_FILE)
+			.withExpectedResponseStatus(NO_CONTENT)
+			.withExpectedResponseBodyIsNull()
+			.sendRequest();
+
+		setupCall()
+			.withHttpMethod(GET)
+			.withServicePath(PATH.replace("asset-drafts", "assets") + "/" + id)
+			.withExpectedResponseStatus(OK)
+			.withExpectedResponse(RESPONSE_FILE)
+			.sendRequestAndVerifyResponse();
+	}
+
+	@Test
 	void test08_createDraftAssetPrivatePartyAndSourceReference() {
 		final var location = setupCall()
 			.withHttpMethod(POST)

--- a/src/integration-test/resources/draftAssetsIT/__files/test09_updateDraftAssetSetIndefinitely/request.json
+++ b/src/integration-test/resources/draftAssetsIT/__files/test09_updateDraftAssetSetIndefinitely/request.json
@@ -1,0 +1,3 @@
+{
+	"indefinitely": true
+}

--- a/src/integration-test/resources/draftAssetsIT/__files/test09_updateDraftAssetSetIndefinitely/response.json
+++ b/src/integration-test/resources/draftAssetsIT/__files/test09_updateDraftAssetSetIndefinitely/response.json
@@ -1,0 +1,15 @@
+{
+	"id": "abd6596f-45a0-4912-89e4-8cdcea9a043a",
+	"assetId": "PRH-0000000004",
+	"origin": "CASEDATA",
+	"partyId": "f2ef7992-7b01-4185-a7f8-cf97dc7f438f",
+	"type": "PERMIT",
+	"issued": "2025-01-01",
+	"status": "DRAFT",
+	"description": "Parkeringstillstånd",
+	"additionalParameters": {
+		"first_key": "first_value",
+		"second_key": "second_value"
+	},
+	"jsonParameters": []
+}

--- a/src/main/java/se/sundsvall/partyassets/api/model/DraftAssetUpdateRequest.java
+++ b/src/main/java/se/sundsvall/partyassets/api/model/DraftAssetUpdateRequest.java
@@ -17,6 +17,9 @@ public class DraftAssetUpdateRequest {
 	@Schema(description = "Valid to date", examples = "2021-12-31")
 	private LocalDate validTo;
 
+	@Schema(description = "If true, validTo will be cleared (asset becomes indefinite). Takes precedence over validTo when both are supplied.", examples = "true")
+	private Boolean indefinitely;
+
 	@Schema(description = "Asset status", examples = "ACTIVE")
 	private Status status;
 
@@ -56,6 +59,19 @@ public class DraftAssetUpdateRequest {
 
 	public DraftAssetUpdateRequest withValidTo(LocalDate validTo) {
 		this.validTo = validTo;
+		return this;
+	}
+
+	public Boolean getIndefinitely() {
+		return indefinitely;
+	}
+
+	public void setIndefinitely(Boolean indefinitely) {
+		this.indefinitely = indefinitely;
+	}
+
+	public DraftAssetUpdateRequest withIndefinitely(Boolean indefinitely) {
+		this.indefinitely = indefinitely;
 		return this;
 	}
 
@@ -113,7 +129,7 @@ public class DraftAssetUpdateRequest {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(additionalParameters, issued, jsonParameters, status, statusReason, validTo);
+		return Objects.hash(additionalParameters, indefinitely, issued, jsonParameters, status, statusReason, validTo);
 	}
 
 	@Override
@@ -128,13 +144,14 @@ public class DraftAssetUpdateRequest {
 			return false;
 		}
 		DraftAssetUpdateRequest other = (DraftAssetUpdateRequest) obj;
-		return Objects.equals(additionalParameters, other.additionalParameters) && Objects.equals(issued, other.issued) && Objects.equals(jsonParameters, other.jsonParameters) && status == other.status && Objects.equals(statusReason,
-			other.statusReason) && Objects.equals(validTo, other.validTo);
+		return Objects.equals(additionalParameters, other.additionalParameters) && Objects.equals(indefinitely, other.indefinitely) && Objects.equals(issued, other.issued) && Objects.equals(jsonParameters, other.jsonParameters) && status == other.status
+			&& Objects.equals(statusReason, other.statusReason) && Objects.equals(validTo, other.validTo);
 	}
 
 	@Override
 	public String toString() {
-		return "DraftAssetUpdateRequest [issued=" + issued + ", validTo=" + validTo + ", status=" + status + ", statusReason=" + statusReason + ", additionalParameters=" + additionalParameters + ", jsonParameters=" + jsonParameters + "]";
+		return "DraftAssetUpdateRequest [issued=" + issued + ", validTo=" + validTo + ", indefinitely=" + indefinitely + ", status=" + status + ", statusReason=" + statusReason + ", additionalParameters=" + additionalParameters + ", jsonParameters="
+			+ jsonParameters + "]";
 	}
 
 }

--- a/src/main/java/se/sundsvall/partyassets/service/mapper/AssetMapper.java
+++ b/src/main/java/se/sundsvall/partyassets/service/mapper/AssetMapper.java
@@ -66,7 +66,11 @@ public final class AssetMapper {
 		Optional.ofNullable(request.getAdditionalParameters()).ifPresent(entity::setAdditionalParameters);
 		Optional.ofNullable(request.getIssued()).ifPresent(entity::setIssued);
 		Optional.ofNullable(request.getJsonParameters()).ifPresent(jsonParameters -> entity.addOrReplaceJsonParameters(toAssetJsonParameterEntityList(jsonParameters)));
-		Optional.ofNullable(request.getValidTo()).ifPresent(entity::setValidTo);
+		if (Boolean.TRUE.equals(request.getIndefinitely())) {
+			entity.setValidTo(null);
+		} else {
+			Optional.ofNullable(request.getValidTo()).ifPresent(entity::setValidTo);
+		}
 		Optional.ofNullable(request.getStatusReason()).ifPresent(entity::setStatusReason);
 		return entity;
 	}

--- a/src/test/java/se/sundsvall/partyassets/api/model/DraftAssetUpdateRequestTest.java
+++ b/src/test/java/se/sundsvall/partyassets/api/model/DraftAssetUpdateRequestTest.java
@@ -42,6 +42,7 @@ class DraftAssetUpdateRequestTest {
 		final var status = Status.ACTIVE;
 		final var statusReason = "statusReason";
 		final var validTo = LocalDate.now();
+		final var indefinitely = true;
 
 		final var bean = DraftAssetUpdateRequest.create()
 			.withAdditionalParameters(additionalParameters)
@@ -49,7 +50,8 @@ class DraftAssetUpdateRequestTest {
 			.withJsonParameters(jsonParameters)
 			.withStatus(status)
 			.withStatusReason(statusReason)
-			.withValidTo(validTo);
+			.withValidTo(validTo)
+			.withIndefinitely(indefinitely);
 
 		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
 		assertThat(bean.getAdditionalParameters()).isEqualTo(additionalParameters);
@@ -58,6 +60,7 @@ class DraftAssetUpdateRequestTest {
 		assertThat(bean.getStatus()).isEqualTo(status);
 		assertThat(bean.getStatusReason()).isEqualTo(statusReason);
 		assertThat(bean.getValidTo()).isEqualTo(validTo);
+		assertThat(bean.getIndefinitely()).isEqualTo(indefinitely);
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/partyassets/service/mapper/AssetMapperTest.java
+++ b/src/test/java/se/sundsvall/partyassets/service/mapper/AssetMapperTest.java
@@ -1,5 +1,6 @@
 package se.sundsvall.partyassets.service.mapper;
 
+import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import se.sundsvall.partyassets.TestFactory;
@@ -102,12 +103,72 @@ class AssetMapperTest {
 		assertThat(entity.getAdditionalParameters()).isEqualTo(request.getAdditionalParameters());
 		assertThat(entity.getIssued()).isEqualTo(request.getIssued());
 		assertThat(entity.getStatusReason()).isEqualTo(request.getStatusReason());
-		assertThat(entity.getValidTo()).isEqualTo(entity.getValidTo());
+		assertThat(entity.getValidTo()).isEqualTo(LocalDate.of(2010, 1, 1));
 
 		// Json params
 		assertThat(entity.getJsonParameters()).hasSize(1);
 		assertThat(entity.getJsonParameters().getFirst().getKey()).isEqualTo("key2");
 		assertThat(entity.getJsonParameters().getFirst().getSchemaId()).isEqualTo("2281_person_schema_2.0.0");
+	}
+
+	@Test
+	void updateEntityWithIndefinitelyTrueClearsValidTo() {
+
+		final var id = UUID.randomUUID().toString();
+		final var partyId = UUID.randomUUID().toString();
+		final var entity = TestFactory.getAssetEntity(id, partyId);
+		final var request = DraftAssetUpdateRequest.create().withIndefinitely(true);
+
+		assertThat(entity.getValidTo()).isNotNull();
+
+		AssetMapper.updateEntity(entity, request);
+
+		assertThat(entity.getValidTo()).isNull();
+	}
+
+	@Test
+	void updateEntityWithIndefinitelyTrueOverridesSuppliedValidTo() {
+
+		final var id = UUID.randomUUID().toString();
+		final var partyId = UUID.randomUUID().toString();
+		final var entity = TestFactory.getAssetEntity(id, partyId);
+		final var request = DraftAssetUpdateRequest.create()
+			.withValidTo(LocalDate.of(2030, 1, 1))
+			.withIndefinitely(true);
+
+		AssetMapper.updateEntity(entity, request);
+
+		assertThat(entity.getValidTo()).isNull();
+	}
+
+	@Test
+	void updateEntityWithIndefinitelyFalseKeepsExistingValidTo() {
+
+		final var id = UUID.randomUUID().toString();
+		final var partyId = UUID.randomUUID().toString();
+		final var original = TestFactory.getAssetEntity(id, partyId);
+		final var entity = TestFactory.getAssetEntity(id, partyId);
+		final var request = DraftAssetUpdateRequest.create().withIndefinitely(false);
+
+		AssetMapper.updateEntity(entity, request);
+
+		assertThat(entity.getValidTo()).isEqualTo(original.getValidTo());
+	}
+
+	@Test
+	void updateEntityWithIndefinitelyFalseAndSuppliedValidToUpdatesValidTo() {
+
+		final var id = UUID.randomUUID().toString();
+		final var partyId = UUID.randomUUID().toString();
+		final var entity = TestFactory.getAssetEntity(id, partyId);
+		final var newValidTo = LocalDate.of(2030, 1, 1);
+		final var request = DraftAssetUpdateRequest.create()
+			.withValidTo(newValidTo)
+			.withIndefinitely(false);
+
+		AssetMapper.updateEntity(entity, request);
+
+		assertThat(entity.getValidTo()).isEqualTo(newValidTo);
 	}
 
 	@Test

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -1,11 +1,11 @@
 openapi: 3.1.0
 info:
   title: api-partyassets
-  contact: {}
+  contact: { }
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "6.1"
+  version: "6.2"
 servers:
   - url: http://localhost:61538
     description: Generated server url
@@ -777,7 +777,7 @@ components:
         instance:
           type: string
           format: uri
-        causeAsProblem: {}
+        causeAsProblem: { }
     Violation:
       type: object
       properties:
@@ -969,6 +969,12 @@ components:
           description: Valid to date
           examples:
             - 2021-12-31
+        indefinitely:
+          type: boolean
+          description: "If true, validTo will be cleared (asset becomes indefinite).\
+            \ Takes precedence over validTo when both are supplied."
+          examples:
+            - "true"
         status:
           $ref: "#/components/schemas/Status"
           description: Asset status
@@ -1059,4 +1065,4 @@ components:
           description: JSON parameters
           items:
             $ref: "#/components/schemas/AssetJsonParameter"
-  securitySchemes: {}
+  securitySchemes: { }


### PR DESCRIPTION
* Added 'indefinitely' boolean to DraftAssetUpdateRequest, allows the user to set validTo to null

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [x] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
