### PR TITLE
  Add a status check in AssetService.updateAsset(DraftAssetUpdateRequ…

### DIFF
--- a/src/main/java/se/sundsvall/partyassets/service/AssetService.java
+++ b/src/main/java/se/sundsvall/partyassets/service/AssetService.java
@@ -100,7 +100,15 @@ public class AssetService {
 	}
 
 	public void updateAsset(final String municipalityId, final String id, final DraftAssetUpdateRequest request) {
-		repository.save(updateEntity(getAssetEntity(municipalityId, id), request));
+		final var entity = getAssetEntity(municipalityId, id);
+		if (entity.getStatus() != DRAFT) {
+			throw Problem.builder()
+				.withStatus(BAD_REQUEST)
+				.withTitle("Invalid asset status")
+				.withDetail("Only DRAFT assets can be updated via this endpoint")
+				.build();
+		}
+		repository.save(updateEntity(entity, request));
 	}
 
 	public void updateAsset(final String municipalityId, final String id, final AssetUpdateRequest request) {

--- a/src/test/java/se/sundsvall/partyassets/service/AssetServiceTest.java
+++ b/src/test/java/se/sundsvall/partyassets/service/AssetServiceTest.java
@@ -331,4 +331,34 @@ class AssetServiceTest {
 		verify(repositoryMock).findByIdAndMunicipalityId(uuid, MUNICIPALITY_ID);
 		verify(repositoryMock, never()).save(any());
 	}
+
+	@Test
+	void updateDraftAsset() {
+		final var id = UUID.randomUUID().toString();
+		final var partyId = UUID.randomUUID().toString();
+		final var entity = getAssetEntity(id, partyId).withStatus(DRAFT);
+
+		when(repositoryMock.findByIdAndMunicipalityId(id, MUNICIPALITY_ID)).thenReturn(Optional.of(entity));
+
+		service.updateAsset(MUNICIPALITY_ID, id, new se.sundsvall.partyassets.api.model.DraftAssetUpdateRequest());
+
+		verify(repositoryMock).findByIdAndMunicipalityId(id, MUNICIPALITY_ID);
+		verify(repositoryMock).save(any(AssetEntity.class));
+	}
+
+	@Test
+	void updateNonDraftAssetViaDraftEndpointThrowsBadRequest() {
+		final var id = UUID.randomUUID().toString();
+		final var partyId = UUID.randomUUID().toString();
+		final var entity = getAssetEntity(id, partyId); // status ACTIVE
+
+		when(repositoryMock.findByIdAndMunicipalityId(id, MUNICIPALITY_ID)).thenReturn(Optional.of(entity));
+
+		assertThatExceptionOfType(ThrowableProblem.class)
+			.isThrownBy(() -> service.updateAsset(MUNICIPALITY_ID, id, new se.sundsvall.partyassets.api.model.DraftAssetUpdateRequest()))
+			.withMessage("Invalid asset status: Only DRAFT assets can be updated via this endpoint");
+
+		verify(repositoryMock).findByIdAndMunicipalityId(id, MUNICIPALITY_ID);
+		verify(repositoryMock, never()).save(any());
+	}
 }


### PR DESCRIPTION
…est) that throws 400 if the asset is not in DRAFT status, preventing from bypassing the more restrictive AssetUpdateRequest

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
